### PR TITLE
FFEATURE: adding reset ix for filtered elements only

### DIFF
--- a/Dist/WebflowOnly/CMSFilter.js
+++ b/Dist/WebflowOnly/CMSFilter.js
@@ -33,6 +33,7 @@ class CMSFilter {
         this.sortOptions = document.querySelector('[wt-cmsfilter-element="sort-options"]');
         this.resultCount = document.querySelector('[wt-cmsfilter-element="results-count"]');
         this.emptyElement = document.querySelector('[wt-cmsfilter-element="empty"]');
+        this.resetIx2 = this.listElement.getAttribute('wt-cmsfilter-resetix2') || false;
 
         //Data Tracking Values
         this.allItems = [];
@@ -206,6 +207,7 @@ class CMSFilter {
                 const currentPage = this.filteredItems.slice(currentSlice, currentSlice + this.itemsPerPage);
                 currentPage.forEach(item => {
                     this.listElement.appendChild(item);
+                    if(this.resetIx2) this.ResetInteraction(item);
                 });
             }
         } else {
@@ -214,10 +216,6 @@ class CMSFilter {
             });
         }
         
-        var webflow = window.Webflow || [];
-        if(webflow) {
-            webflow.require('ix2').init();
-        }
         this.ToggleEmptyState();
         this.UpdatePaginationDisplay();
     }
@@ -291,7 +289,6 @@ class CMSFilter {
         this.ShowResultCount();
         this.SetActiveTags();
     }
-
 
     ShowResultCount() {
         if(!this.resultCount) return;
@@ -369,7 +366,6 @@ class CMSFilter {
         return filters;
     }
     
-
     GetDataSet(str) {
         return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function(word, index) {
             return index === 0 ? word.toLowerCase() : word.toUpperCase();
@@ -565,6 +561,37 @@ class CMSFilter {
         this.ApplyFilters();
     }
     
+    ResetInteraction(element) {
+        if (!element) {
+            console.error('Element not found');
+            return;
+        }
+
+        const WebflowIX2 = window.Webflow && Webflow.require('ix2');
+        if (!WebflowIX2) {
+            console.error('Webflow IX2 engine not found.');
+            return;
+        }
+
+        const targetElement = element.hasAttribute('data-w-id') 
+            ? element 
+            : element.querySelector('[data-w-id]');
+        
+        if (!targetElement) {
+            console.warn('No IX2 interaction found on the element or its children.');
+            return;
+        }
+
+        const dataWId = targetElement.getAttribute('data-w-id');
+        if (dataWId) {
+            targetElement.removeAttribute('data-w-id');
+            targetElement.setAttribute('data-w-id', dataWId);
+
+            WebflowIX2.init();
+        } else {
+            console.warn('No valid data-w-id attribute found.');
+        }
+    }
 
     GetFilterData() {
         let filterData = {


### PR DESCRIPTION
# New Feature: adding reset ix for list elements only

## Description
Reset IX Setup that was placed was resetting the IX2 for all elements instead of only for the elements in the list that is being filtered. Fixed this issue adding a new function and attribute on the CMSFilter script to reset only the elements that are being added to the list.

## Related Issues
- Link any issues related to this feature (e.g., `Fixes #123`).
Fixes #35 

## Script Details
- **Script Name**: CMS Filter
- **Purpose of Update**: Update ResetIX 
- **New Behavior**: Added a function to properly reset only required elements

## Changes Made
- Removed the old reset IX behaviour and added a new function to reset the interactions on the elements required ONLY IF a flag is present in the list.


**This PR closes #35**

## Checklist
<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] Feature has been tested locally with all relevant use cases.
- [x] PR does not match another non-stale PR currently opened
- [x] PR name matches the format *[ feature ]: <i>Feature Name</i>
- [x] PR's base is the `develop` branch.
- [x] Your Feature matches the standards laid out [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Programming-Standards)
