### PR TITLE
Update: Fix on issue with render static

### DIFF
--- a/Dist/WebflowOnly/RenderStatic.js
+++ b/Dist/WebflowOnly/RenderStatic.js
@@ -25,15 +25,17 @@ class RenderStatic {
 
         let insertIndex = this.gap;
         const totalChildren = childrenArray.length;
-        const totalInsertions = Math.round(totalChildren / this.gap);
         let cloneIndex = 0;
 
-        for (let i = 0; i <= totalChildren + totalInsertions; i++) {
-            if (i === insertIndex) {
-                this.insertChildAtIndex(this.container, this.cloneables[cloneIndex], insertIndex);
-                cloneIndex = (cloneIndex < this.cloneables.length - 1) ? cloneIndex + 1 : 0;
-                insertIndex = i + this.gap + 1;
-            }
+        const maxInsertions = Math.floor((totalChildren - 1) / this.gap);
+
+        for (let i = 0; i < maxInsertions; i++) {
+            const currentIndex = i * (this.gap + 1) + this.gap;
+
+            if (currentIndex >= totalChildren) break;
+
+            this.insertChildAtIndex(this.container, this.cloneables[cloneIndex], currentIndex);
+            cloneIndex = (cloneIndex < this.cloneables.length - 1) ? cloneIndex + 1 : 0;
         }
         
         this.observeContainer();
@@ -41,7 +43,9 @@ class RenderStatic {
 
     insertChildAtIndex(parent, child, index = 0) {
         if (!child) return;
-        if (parent.children.length === index) return;
+
+        if (index >= parent.children.length) return;
+
         let childClone = child.cloneNode(true);
         if (parent) {
             parent.insertBefore(childClone, parent.children[index]);
@@ -77,5 +81,5 @@ const initializeRenderStatic = () => {
 if (/complete|interactive|loaded/.test(document.readyState)) {
     initializeRenderStatic();
 } else { 
-    window.addEventListener('DOMContentLoaded',initializeRenderStatic )
+    window.addEventListener('DOMContentLoaded', initializeRenderStatic);
 }


### PR DESCRIPTION
## Description
There was a bug on Render static that would cause it to render multiple static elements at the end of the list.


## Script Details
- **Script Name**: Render Static
- **Purpose of Update**: Fixing a small visual bug
- **New Behavior**: Static elements are not allowed as the last elements of the list.

## Changes Made
added an update to prevent the static elements from being shown at the end of the cms list

**This PR closes NONE**

## Checklist
<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] Feature has been tested locally with all relevant use cases.
- [x] Documentation has been updated (if necessary).
- [x] PR does not match another non-stale PR currently opened
- [x] PR name matches the format *[ Update ]: <i>Update Name</i> 
- [x] PR's base is the `develop` branch.
- [x] Your Update matches the standards laid out [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Programming-Standards)
<!-- Refer to the [contributing](https://github.com/TheCodeRaccoons/WebTricks/wiki/Contributing) guidelines for more details. -->
