### PR TITLE
Fix: Added Render static affordance to CMS Filter

### DIFF
--- a/Dist/WebflowOnly/CMSFilter.js
+++ b/Dist/WebflowOnly/CMSFilter.js
@@ -520,8 +520,10 @@ class CMSFilter {
             }
         } 
         if(this.allItems){
-            if(this.allItems.length > 0) {
-                return this.allItems.length;
+            //trim out static elements from RenderStatic
+            let elements = this.allItems.filter(item => !item.hasAttribute('wt-renderstatic-element'));
+            if(elements.length > 0) {
+                return elements.length;
             }
             return 0;
         }


### PR DESCRIPTION

# New Feature: [Feature Title]

## Description
when using CMS filter along with RenderStatic an issue shows up in which the result count shows the total of results + the render-static results ONLY WHEN NO FILTERS SELECTED, added an affordance to prevent this from happening

## Script Details
- **Script Name**: CMS Filter
- **Purpose of Update**: see description for full reasons
- **New Behavior**: when no filters are selected and using Render Static + CMS Filter the static elements are not counted in the results count

## Changes Made
- Updated the CMSFilter's getResults function adding a filtering to take out the elements with the renderstatic attribute so both scripts can work together

**This PR closes NONE**

## Checklist
<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] Feature has been tested locally with all relevant use cases.
- [x] Documentation has been updated (if necessary).
- [x] PR does not match another non-stale PR currently opened
- [x] PR name matches the format *[ Fix ]: <i>Fix Name</i> (<i>versions separated by comma</i>)*. More details [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Overview-on-Submitting-Features)
- [x] PR's base is the `develop` branch.
- [x] Your Feature matches the standards laid out [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Programming-Standards)
<!-- Refer to the [contributing](https://github.com/TheCodeRaccoons/WebTricks/wiki/Contributing) guidelines for more details. -->
