### PR TITLE
Update: Adding reset-ix2 to renderstatic - closes #39

### DIFF
--- a/Dist/WebflowOnly/RenderStatic.js
+++ b/Dist/WebflowOnly/RenderStatic.js
@@ -4,6 +4,8 @@ class RenderStatic {
     constructor(_container) {
         this.container = _container;
         this.cloneables = document.querySelectorAll("[wt-renderstatic-element='cloneable']");
+        this.resetIx2 = this.container.getAttribute('wt-renderstatic-resetix2') || false;
+
         this.gap = 0;
         this.observer = null;
 
@@ -49,6 +51,7 @@ class RenderStatic {
         let childClone = child.cloneNode(true);
         if (parent) {
             parent.insertBefore(childClone, parent.children[index]);
+            if(this.resetIx2) this.ResetInteraction(childClone);
         }
     }
 
@@ -67,6 +70,38 @@ class RenderStatic {
         });
 
         this.observer.observe(this.container, { childList: true });
+    }
+    
+    ResetInteraction(element) {
+        if (!element) {
+            console.error('Element not found');
+            return;
+        }
+
+        const WebflowIX2 = window.Webflow && Webflow.require('ix2');
+        if (!WebflowIX2) {
+            console.error('Webflow IX2 engine not found.');
+            return;
+        }
+
+        const targetElement = element.hasAttribute('data-w-id') 
+            ? element 
+            : element.querySelector('[data-w-id]');
+        
+        if (!targetElement) {
+            console.warn('No IX2 interaction found on the element or its children.');
+            return;
+        }
+
+        const dataWId = targetElement.getAttribute('data-w-id');
+        if (dataWId) {
+            targetElement.removeAttribute('data-w-id');
+            targetElement.setAttribute('data-w-id', dataWId);
+
+            WebflowIX2.init();
+        } else {
+            console.warn('No valid data-w-id attribute found.');
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Added Reset IX2 function to reset animations for elements coming from RenderStatic

## Related Issues
This PR Fixes Issue #39 

## Script Details
- **Script Name**: RenderStatic
- **Purpose of Update**: Added Reset Webflow Animations to script
- **New Behavior**: Can now trigger Webflow animations on the elements again when the flag is active

## Changes Made
- Added the ResetInteraction function which reset the IX2 webflow native animations based on the wt-renderstatic-resetix2 attribute

## Checklist
<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] Feature has been tested locally with all relevant use cases.
- [x] Documentation has been updated (if necessary).
- [x] PR does not match another non-stale PR currently opened
- [x] PR's base is the `develop` branch.
- [x] Your Feature matches the standards laid out [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Programming-Standards)
<!-- Refer to the [contributing](https://github.com/TheCodeRaccoons/WebTricks/wiki/Contributing) guidelines for more details. -->