### PR TITLE
Update contributors-readme-action to version 2.3.11

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update contributors section in README
-        uses: akhilmhdh/contributors-readme-action@v2
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This pull request updates the GitHub Action used to maintain the contributors section in the README. The action version has been bumped to ensure the workflow uses the latest available features and fixes.