### PR TITLE
Add pull-requests write permission to workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a minor update to the workflow permissions in `.github/workflows/update-contributors.yml`, ensuring the workflow can write to pull requests.

* Added `pull-requests: write` permission to the workflow to enable write access to pull requests.