### PR TITLE
Feature/hybrid cms filtering

### DIFF
--- a/Dist/WebflowOnly/CMSFilter.js
+++ b/Dist/WebflowOnly/CMSFilter.js
@@ -1,6 +1,13 @@
 "use strict";
 
 class CMSFilter {
+  /**
+   * For `wt-cmsfilter-filtering="hybrid"`, availability for these categories ignores
+   * that category's active filters (e.g. body type options stay available for multi-select
+   * while other facets narrow from the full filtered set).
+   */
+  static HYBRID_SELF_EXCLUDE_CATEGORIES = ["bodytype"];
+
   constructor() {
     //CORE elements
     this.filterForm = document.querySelector(
@@ -559,88 +566,100 @@ class CMSFilter {
     });
   }
 
-  ApplyFilters() {
-    const filters = this.GetFilters();
-    this.currentPage = 1; // Reset pagination to first page
-    this.filteredItems = this.allItems.filter((item) => {
-      return Object.keys(filters).every((category) => {
-        // Fix 1: Safari-compatible array handling
-        const categoryFilters = filters[category] || [];
-        const values = Array.isArray(categoryFilters)
-          ? categoryFilters.slice()
-          : [];
-        if (values.length === 0) return true;
+  /**
+   * Whether a single list item matches the given filter map (same rules as ApplyFilters).
+   */
+  itemMatchesFilters(item, filters) {
+    return Object.keys(filters).every((category) => {
+      const categoryFilters = filters[category] || [];
+      const values = Array.isArray(categoryFilters)
+        ? categoryFilters.slice()
+        : [];
+      if (values.length === 0) return true;
 
-        // Use cached search data instead of live DOM queries
-        const searchCache = item._wtSearchCache;
-        if (!searchCache) {
-          console.warn(
-            "Search cache missing for item, falling back to live query",
-          );
-          // Fallback to original method if cache is missing
-          const categoryElement = item.querySelector(
-            `[wt-cmsfilter-category="${category}"]`,
-          );
-          let matchingText = "";
-          if (categoryElement && categoryElement.innerText) {
-            matchingText = categoryElement.innerText.toLowerCase();
-          }
-          matchingText = matchingText.replace(/(?:&nbsp;|\s)+/gi, " ");
+      const searchCache = item._wtSearchCache;
+      if (!searchCache) {
+        console.warn(
+          "Search cache missing for item, falling back to live query",
+        );
+        const categoryElement = item.querySelector(
+          `[wt-cmsfilter-category="${category}"]`,
+        );
+        let matchingText = "";
+        if (categoryElement && categoryElement.innerText) {
+          matchingText = categoryElement.innerText.toLowerCase();
         }
+        matchingText = matchingText.replace(/(?:&nbsp;|\s)+/gi, " ");
+      }
 
-        if (category === "*") {
-          // Global search using cached text
-          const globalText = searchCache ? searchCache.globalSearchText : "";
-          return (
-            values.some((value) => globalText.includes(value.toLowerCase())) ||
-            Object.values(item.dataset || {}).some((dataValue) =>
-              values.some((value) => {
-                if (dataValue && typeof dataValue.toLowerCase === "function") {
-                  return dataValue.toLowerCase().includes(value.toLowerCase());
-                }
-                return false;
-              }),
-            )
-          );
-        } else {
-          return values.some((value) => {
-            if (typeof value === "object" && value !== null) {
-              // Range filtering - use normalized dataset key
-              const datasetCategory = this.GetDataSet(category);
-              const datasetValue =
-                item.dataset && item.dataset[datasetCategory]
-                  ? item.dataset[datasetCategory]
-                  : "";
-              const itemValue = parseFloat(datasetValue);
-              if (isNaN(itemValue)) return false;
-              if (value.from !== null && value.to !== null) {
-                return itemValue >= value.from && itemValue <= value.to;
-              } else if (value.from !== null && value.to == null) {
-                return itemValue >= value.from;
-              } else if (value.from == null && value.to !== null) {
-                return itemValue <= value.to;
+      if (category === "*") {
+        const globalText = searchCache ? searchCache.globalSearchText : "";
+        return (
+          values.some((value) => globalText.includes(value.toLowerCase())) ||
+          Object.values(item.dataset || {}).some((dataValue) =>
+            values.some((value) => {
+              if (dataValue && typeof dataValue.toLowerCase === "function") {
+                return dataValue.toLowerCase().includes(value.toLowerCase());
               }
               return false;
-            } else {
-              // Text filtering using cached data
-              const datasetCategory = this.GetDataSet(category);
-              const cachedDatasetValue = searchCache
-                ? searchCache.datasetValues.get(datasetCategory) || ""
-                : "";
-              const cachedCategoryText = searchCache
-                ? searchCache.categoryTexts.get(category) || ""
-                : "";
-              const valueStr = value ? value.toString().toLowerCase() : "";
+            }),
+          )
+        );
+      }
+      return values.some((value) => {
+        if (typeof value === "object" && value !== null) {
+          const datasetCategory = this.GetDataSet(category);
+          const datasetValue =
+            item.dataset && item.dataset[datasetCategory]
+              ? item.dataset[datasetCategory]
+              : "";
+          const itemValue = parseFloat(datasetValue);
+          if (isNaN(itemValue)) return false;
+          if (value.from !== null && value.to !== null) {
+            return itemValue >= value.from && itemValue <= value.to;
+          } else if (value.from !== null && value.to == null) {
+            return itemValue >= value.from;
+          } else if (value.from == null && value.to !== null) {
+            return itemValue <= value.to;
+          }
+          return false;
+        } else {
+          const datasetCategory = this.GetDataSet(category);
+          const cachedDatasetValue = searchCache
+            ? searchCache.datasetValues.get(datasetCategory) || ""
+            : "";
+          const cachedCategoryText = searchCache
+            ? searchCache.categoryTexts.get(category) || ""
+            : "";
+          const valueStr = value ? value.toString().toLowerCase() : "";
 
-              return (
-                cachedDatasetValue.includes(valueStr) ||
-                cachedCategoryText.includes(valueStr)
-              );
-            }
-          });
+          return (
+            cachedDatasetValue.includes(valueStr) ||
+            cachedCategoryText.includes(valueStr)
+          );
         }
       });
     });
+  }
+
+  /**
+   * Items matching current filters but ignoring one or more categories (for hybrid availability).
+   */
+  getFilteredItemsIgnoringCategories(excludedCategoryAttrs) {
+    const filters = this.GetFilters();
+    const f = { ...filters };
+    excludedCategoryAttrs.forEach((cat) => {
+      f[cat] = [];
+    });
+    return this.allItems.filter((item) => this.itemMatchesFilters(item, f));
+  }
+
+  ApplyFilters() {
+    const filters = this.GetFilters();
+    this.currentPage = 1; // Reset pagination to first page
+    this.filteredItems = this.allItems.filter((item) =>
+      this.itemMatchesFilters(item, filters),
+    );
 
     this.activeFilters = filters;
     this.SortItems();
@@ -766,18 +785,29 @@ class CMSFilter {
   }
 
   UpdateAvailableFilters() {
-    if (this.filterForm.getAttribute("wt-cmsfilter-filtering") !== "advanced")
-      return;
+    const filteringMode = this.filterForm.getAttribute(
+      "wt-cmsfilter-filtering",
+    );
+    if (filteringMode !== "advanced" && filteringMode !== "hybrid") return;
+
     this.availableFilters = {};
 
     this.filterElements.forEach((element) => {
-      const category = this.GetDataSet(
-        element.getAttribute("wt-cmsfilter-category"),
-      );
+      const categoryAttr = element.getAttribute("wt-cmsfilter-category");
+      const category = this.GetDataSet(categoryAttr);
+
+      let sourceItems = this.filteredItems;
+      if (
+        filteringMode === "hybrid" &&
+        categoryAttr &&
+        CMSFilter.HYBRID_SELF_EXCLUDE_CATEGORIES.includes(categoryAttr)
+      ) {
+        sourceItems = this.getFilteredItemsIgnoringCategories([categoryAttr]);
+      }
 
       // Safari-compatible dataset access
       const availableValues = new Set(
-        this.filteredItems
+        sourceItems
           .map((item) =>
             item.dataset && item.dataset[category]
               ? item.dataset[category]
@@ -919,7 +949,10 @@ class CMSFilter {
             input.value = "";
           }
         } else if (input.type === "checkbox") {
-          if (advancedFiltering === "advanced") {
+          if (
+            advancedFiltering === "advanced" ||
+            advancedFiltering === "hybrid"
+          ) {
             input.checked = false;
           } else {
             if (categoryElement.innerText === value) {

--- a/Dist/WebflowOnly/CMSFilter.js
+++ b/Dist/WebflowOnly/CMSFilter.js
@@ -780,20 +780,19 @@ class CMSFilter {
   /**
    * Categories whose checkbox availability ignores that facet’s own selections (hybrid mode).
    * Set on the form: wt-cmsfilter-hybrid-categories="bodytype" or "bodytype,colour"
-   * If the attribute is omitted, defaults to ["bodytype"]. If present but empty, no categories self-exclude.
+   * Omit or leave empty for no self-exclude categories (hybrid availability matches advanced for every facet).
    */
   getHybridSelfExcludeCategories() {
     const raw = this.filterForm.getAttribute(
       "wt-cmsfilter-hybrid-categories",
     );
-    if (raw === null) {
-      return ["bodytype"];
+    if (raw === null || raw.trim() === "") {
+      return [];
     }
-    const parsed = raw
+    return raw
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean);
-    return parsed;
   }
 
   UpdateAvailableFilters() {

--- a/Dist/WebflowOnly/CMSFilter.js
+++ b/Dist/WebflowOnly/CMSFilter.js
@@ -1,13 +1,6 @@
 "use strict";
 
 class CMSFilter {
-  /**
-   * For `wt-cmsfilter-filtering="hybrid"`, availability for these categories ignores
-   * that category's active filters (e.g. body type options stay available for multi-select
-   * while other facets narrow from the full filtered set).
-   */
-  static HYBRID_SELF_EXCLUDE_CATEGORIES = ["bodytype"];
-
   constructor() {
     //CORE elements
     this.filterForm = document.querySelector(
@@ -784,6 +777,25 @@ class CMSFilter {
     });
   }
 
+  /**
+   * Categories whose checkbox availability ignores that facet’s own selections (hybrid mode).
+   * Set on the form: wt-cmsfilter-hybrid-categories="bodytype" or "bodytype,colour"
+   * If the attribute is omitted, defaults to ["bodytype"]. If present but empty, no categories self-exclude.
+   */
+  getHybridSelfExcludeCategories() {
+    const raw = this.filterForm.getAttribute(
+      "wt-cmsfilter-hybrid-categories",
+    );
+    if (raw === null) {
+      return ["bodytype"];
+    }
+    const parsed = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return parsed;
+  }
+
   UpdateAvailableFilters() {
     const filteringMode = this.filterForm.getAttribute(
       "wt-cmsfilter-filtering",
@@ -800,7 +812,7 @@ class CMSFilter {
       if (
         filteringMode === "hybrid" &&
         categoryAttr &&
-        CMSFilter.HYBRID_SELF_EXCLUDE_CATEGORIES.includes(categoryAttr)
+        this.getHybridSelfExcludeCategories().includes(categoryAttr)
       ) {
         sourceItems = this.getFilteredItemsIgnoringCategories([categoryAttr]);
       }

--- a/__tests__/CMSFilter.test.js
+++ b/__tests__/CMSFilter.test.js
@@ -73,6 +73,33 @@ describe("CMSFilter", () => {
     `;
   }
 
+  /** make, bodytype, Category — hybrid (bodytype self-exclude) vs advanced */
+  function buildHybridScenarioDOM(filteringMode = "hybrid") {
+    const modeAttr = filteringMode
+      ? `wt-cmsfilter-filtering="${filteringMode}"`
+      : "";
+    document.body.innerHTML = `
+      <form wt-cmsfilter-element="filter-form" ${modeAttr} wt-cmsfilter-debounce="0">
+        <label wt-cmsfilter-category="make"><input type="checkbox"><span>Toyota</span></label>
+        <label wt-cmsfilter-category="make"><input type="checkbox"><span>Honda</span></label>
+        <label wt-cmsfilter-category="bodytype"><input type="checkbox"><span>SUV</span></label>
+        <label wt-cmsfilter-category="bodytype"><input type="checkbox"><span>Sedan</span></label>
+        <label wt-cmsfilter-category="Category"><input type="checkbox"><span>Red</span></label>
+        <label wt-cmsfilter-category="Category"><input type="checkbox"><span>Blue</span></label>
+        <label wt-cmsfilter-category="*"><input type="text" /></label>
+        <select wt-cmsfilter-element="sort-options"><option value="title-asc">A</option></select>
+        <div wt-cmsfilter-element="results-count"></div>
+      </form>
+      <div id="tags-wrapper"><div wt-cmsfilter-element="tag-template"><span wt-cmsfilter-element="tag-text"></span><a href="#" wt-cmsfilter-element="tag-remove">x</a></div></div>
+      <div wt-cmsfilter-element="list">
+        <div class="item" data-title="t1" data-make="Toyota" data-bodytype="SUV" data-category="Red">T1</div>
+        <div class="item" data-title="t2" data-make="Toyota" data-bodytype="Sedan" data-category="Red">T2</div>
+        <div class="item" data-title="h1" data-make="Honda" data-bodytype="SUV" data-category="Blue">H1</div>
+      </div>
+      <div wt-cmsfilter-element="empty" style="display:none;"></div>
+    `;
+  }
+
   test("initializes and caches items, pushes instance", () => {
     buildBasicDOM();
     InitializeCMSFilter();
@@ -170,6 +197,74 @@ describe("CMSFilter", () => {
     const instance = window.webtricks[0].CMSFilter;
     const ordered = instance.filteredItems.map((i) => i.dataset.title);
     expect(ordered).toEqual(["gamma", "beta", "alpha"]);
+  });
+
+  test("hybrid mode narrows make like advanced but keeps all relevant body types visible for multi-select", () => {
+    buildHybridScenarioDOM("hybrid");
+    InitializeCMSFilter();
+    const form = document.querySelector('[wt-cmsfilter-element="filter-form"]');
+    const toyota = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="make"]'),
+    ).find((l) => l.textContent.includes("Toyota"));
+    const suv = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="bodytype"]'),
+    ).find((l) => l.textContent.includes("SUV"));
+    toyota.querySelector("input").checked = true;
+    suv.querySelector("input").checked = true;
+    toyota
+      .querySelector("input")
+      .dispatchEvent(new Event("change", { bubbles: true }));
+    suv.querySelector("input").dispatchEvent(new Event("change", { bubbles: true }));
+    const instance = window.webtricks[0].CMSFilter;
+    instance.ApplyFilters();
+
+    expect(instance.filteredItems.length).toBe(1);
+    const makeLabels = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="make"]'),
+    );
+    const visibleMake = makeLabels.filter((l) => l.style.display !== "none");
+    expect(visibleMake.map((l) => l.textContent.trim())).toEqual(["Toyota"]);
+
+    const bodyLabels = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="bodytype"]'),
+    );
+    const visibleBody = bodyLabels.filter((l) => l.style.display !== "none");
+    expect(visibleBody.map((l) => l.textContent.trim()).sort()).toEqual([
+      "SUV",
+      "Sedan",
+    ]);
+  });
+
+  test("advanced mode hides sibling make and hides body types not in result set", () => {
+    buildHybridScenarioDOM("advanced");
+    InitializeCMSFilter();
+    const form = document.querySelector('[wt-cmsfilter-element="filter-form"]');
+    const toyota = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="make"]'),
+    ).find((l) => l.textContent.includes("Toyota"));
+    const suv = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="bodytype"]'),
+    ).find((l) => l.textContent.includes("SUV"));
+    toyota.querySelector("input").checked = true;
+    suv.querySelector("input").checked = true;
+    toyota
+      .querySelector("input")
+      .dispatchEvent(new Event("change", { bubbles: true }));
+    suv.querySelector("input").dispatchEvent(new Event("change", { bubbles: true }));
+    const instance = window.webtricks[0].CMSFilter;
+    instance.ApplyFilters();
+
+    const makeLabels = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="make"]'),
+    );
+    const visibleMake = makeLabels.filter((l) => l.style.display !== "none");
+    expect(visibleMake.map((l) => l.textContent.trim())).toEqual(["Toyota"]);
+
+    const bodyLabels = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="bodytype"]'),
+    );
+    const visibleBody = bodyLabels.filter((l) => l.style.display !== "none");
+    expect(visibleBody.map((l) => l.textContent.trim())).toEqual(["SUV"]);
   });
 
   test("advanced filtering hides unavailable checkboxes then restores after clearing", () => {

--- a/__tests__/CMSFilter.test.js
+++ b/__tests__/CMSFilter.test.js
@@ -74,12 +74,19 @@ describe("CMSFilter", () => {
   }
 
   /** make, bodytype, Category — hybrid (bodytype self-exclude) vs advanced */
-  function buildHybridScenarioDOM(filteringMode = "hybrid") {
+  function buildHybridScenarioDOM(
+    filteringMode = "hybrid",
+    hybridCategoriesAttr,
+  ) {
     const modeAttr = filteringMode
       ? `wt-cmsfilter-filtering="${filteringMode}"`
       : "";
+    const hybridAttr =
+      hybridCategoriesAttr !== undefined
+        ? `wt-cmsfilter-hybrid-categories="${hybridCategoriesAttr}"`
+        : "";
     document.body.innerHTML = `
-      <form wt-cmsfilter-element="filter-form" ${modeAttr} wt-cmsfilter-debounce="0">
+      <form wt-cmsfilter-element="filter-form" ${modeAttr} ${hybridAttr} wt-cmsfilter-debounce="0">
         <label wt-cmsfilter-category="make"><input type="checkbox"><span>Toyota</span></label>
         <label wt-cmsfilter-category="make"><input type="checkbox"><span>Honda</span></label>
         <label wt-cmsfilter-category="bodytype"><input type="checkbox"><span>SUV</span></label>
@@ -233,6 +240,32 @@ describe("CMSFilter", () => {
       "SUV",
       "Sedan",
     ]);
+  });
+
+  test("hybrid with empty wt-cmsfilter-hybrid-categories narrows all facets like advanced", () => {
+    buildHybridScenarioDOM("hybrid", "");
+    InitializeCMSFilter();
+    const form = document.querySelector('[wt-cmsfilter-element="filter-form"]');
+    const toyota = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="make"]'),
+    ).find((l) => l.textContent.includes("Toyota"));
+    const suv = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="bodytype"]'),
+    ).find((l) => l.textContent.includes("SUV"));
+    toyota.querySelector("input").checked = true;
+    suv.querySelector("input").checked = true;
+    toyota
+      .querySelector("input")
+      .dispatchEvent(new Event("change", { bubbles: true }));
+    suv.querySelector("input").dispatchEvent(new Event("change", { bubbles: true }));
+    const instance = window.webtricks[0].CMSFilter;
+    instance.ApplyFilters();
+
+    const bodyLabels = Array.from(
+      form.querySelectorAll('label[wt-cmsfilter-category="bodytype"]'),
+    );
+    const visibleBody = bodyLabels.filter((l) => l.style.display !== "none");
+    expect(visibleBody.map((l) => l.textContent.trim())).toEqual(["SUV"]);
   });
 
   test("advanced mode hides sibling make and hides body types not in result set", () => {

--- a/__tests__/CMSFilter.test.js
+++ b/__tests__/CMSFilter.test.js
@@ -74,16 +74,13 @@ describe("CMSFilter", () => {
   }
 
   /** make, bodytype, Category — hybrid (bodytype self-exclude) vs advanced */
-  function buildHybridScenarioDOM(
-    filteringMode = "hybrid",
-    hybridCategoriesAttr,
-  ) {
+  function buildHybridScenarioDOM(filteringMode = "hybrid", hybridCategoriesAttr) {
     const modeAttr = filteringMode
       ? `wt-cmsfilter-filtering="${filteringMode}"`
       : "";
     const hybridAttr =
-      hybridCategoriesAttr !== undefined
-        ? `wt-cmsfilter-hybrid-categories="${hybridCategoriesAttr}"`
+      filteringMode === "hybrid"
+        ? ` wt-cmsfilter-hybrid-categories="${hybridCategoriesAttr ?? ""}"`
         : "";
     document.body.innerHTML = `
       <form wt-cmsfilter-element="filter-form" ${modeAttr} ${hybridAttr} wt-cmsfilter-debounce="0">
@@ -207,7 +204,7 @@ describe("CMSFilter", () => {
   });
 
   test("hybrid mode narrows make like advanced but keeps all relevant body types visible for multi-select", () => {
-    buildHybridScenarioDOM("hybrid");
+    buildHybridScenarioDOM("hybrid", "bodytype");
     InitializeCMSFilter();
     const form = document.querySelector('[wt-cmsfilter-element="filter-form"]');
     const toyota = Array.from(

--- a/docs/WebflowOnly/CMSFilter.md
+++ b/docs/WebflowOnly/CMSFilter.md
@@ -49,7 +49,7 @@ Add the script to your Webflow project and include the required attributes on yo
 
 - `wt-cmsfilter-filtering="advanced"` - Enables advanced filtering mode with dynamic availability updates (every facet’s options narrow to the current result set; selecting one **make** hides other makes).
 - `wt-cmsfilter-filtering="hybrid"` - Like advanced, but selected categories (see below) keep **all** of their checkbox options that match the current filters **except** that category’s own selections (multi-select friendly). All **other** categories narrow from the current result set like **`advanced`**.
-- `wt-cmsfilter-hybrid-categories="bodytype"` - Comma-separated `wt-cmsfilter-category` names that use hybrid self-exclude behavior (e.g. `bodytype` or `bodytype,colour`). **If omitted**, defaults to **`bodytype`**. **If present but empty**, every facet narrows like **`advanced`** (no hybrid self-exclude). Requires matching `data-*` fields on list items for each listed category.
+- `wt-cmsfilter-hybrid-categories="bodytype"` - Comma-separated `wt-cmsfilter-category` names that use hybrid self-exclude behavior (e.g. `bodytype` or `bodytype,colour`). **Required** for any facet to use hybrid self-exclude; **omit or leave empty** if every facet should narrow like **`advanced`**. Requires matching `data-*` fields on list items for each listed category.
 - `wt-cmsfilter-trigger="button"` - Changes filter trigger to button submit instead of real-time
 - `wt-cmsfilter-class="classname"` - CSS class applied to active filter elements
 - `wt-cmsfilter-resetix2="true"` - Reset IX2 interactions on filtered items

--- a/docs/WebflowOnly/CMSFilter.md
+++ b/docs/WebflowOnly/CMSFilter.md
@@ -12,7 +12,7 @@ CMSFilter is a powerful Webflow-specific script that provides advanced filtering
 
 - Multiple filter types (checkbox, radio, text, range)
 - Advanced filtering with dynamic availability updates
-- Hybrid filtering mode (`hybrid`): advanced-style narrowing for **make** and other facets, while **body type** options stay available for multi-select
+- Hybrid filtering mode (`hybrid` + `wt-cmsfilter-hybrid-categories`): like advanced, but listed categories keep sibling checkbox options for multi-select; other facets narrow from the current result set
 - Pagination support with auto-loading across pages
 - Dynamic sorting (numeric, date, alphabetical)
 - Active filter tags with individual removal
@@ -213,6 +213,27 @@ Add the script to your Webflow project and include the required attributes on yo
 </form>
 ```
 
+### Hybrid mode (advanced + multi-select on chosen facets)
+
+Use **`hybrid`** instead of **`advanced`** on the form, and set **`wt-cmsfilter-hybrid-categories`** to a comma-separated list of `wt-cmsfilter-category` values that should **not** hide sibling options when you select one value (e.g. body type so users can pick SUV and Minivan at once). **Omit** `wt-cmsfilter-hybrid-categories` or leave it **empty** if every facet should narrow like **`advanced`**. List items need matching `data-*` fields for each category you name.
+
+```html
+<form wt-cmsfilter-element="filter-form"
+      wt-cmsfilter-filtering="hybrid"
+      wt-cmsfilter-hybrid-categories="bodytype"
+      wt-cmsfilter-debounce="300">
+    <!-- make, model, etc.: narrow like advanced -->
+    <label wt-cmsfilter-category="make"><input type="checkbox"><span>Toyota</span></label>
+    <!-- bodytype: sibling options stay available for multi-select -->
+    <label wt-cmsfilter-category="bodytype"><input type="checkbox"><span>SUV</span></label>
+    <div wt-cmsfilter-element="list">
+        <div data-make="Toyota" data-bodytype="SUV">…</div>
+    </div>
+</form>
+```
+
+Multiple categories: `wt-cmsfilter-hybrid-categories="bodytype,colour"`.
+
 ### Button-Triggered Filtering
 
 ```html
@@ -250,7 +271,7 @@ Add the script to your Webflow project and include the required attributes on yo
 
 - Use debouncing for text inputs in large collections (adjust `wt-cmsfilter-debounce` value)
 - Enable pagination for collections with 50+ items
-- Use advanced filtering mode only when needed for better performance
+- Use advanced or hybrid filtering mode only when needed for better performance
 - Implement IX2 reset (`wt-cmsfilter-resetix2="true"`) sparingly as it impacts performance
 - Consider using button-triggered filtering for complex filter sets
 

--- a/docs/WebflowOnly/CMSFilter.md
+++ b/docs/WebflowOnly/CMSFilter.md
@@ -48,7 +48,8 @@ Add the script to your Webflow project and include the required attributes on yo
 #### Core Filter Attributes
 
 - `wt-cmsfilter-filtering="advanced"` - Enables advanced filtering mode with dynamic availability updates (every facet’s options narrow to the current result set; selecting one **make** hides other makes).
-- `wt-cmsfilter-filtering="hybrid"` - Like advanced, but **`bodytype`** keeps **all** of its checkbox options that match the current filters **except** body type (so users can multi-select e.g. Minivan and SUV while other facets react). **`make`** and all other categories narrow from the current result set like **`advanced`**. Requires matching `data-bodytype` on list items (`wt-cmsfilter-category="bodytype"`).
+- `wt-cmsfilter-filtering="hybrid"` - Like advanced, but selected categories (see below) keep **all** of their checkbox options that match the current filters **except** that category’s own selections (multi-select friendly). All **other** categories narrow from the current result set like **`advanced`**.
+- `wt-cmsfilter-hybrid-categories="bodytype"` - Comma-separated `wt-cmsfilter-category` names that use hybrid self-exclude behavior (e.g. `bodytype` or `bodytype,colour`). **If omitted**, defaults to **`bodytype`**. **If present but empty**, every facet narrows like **`advanced`** (no hybrid self-exclude). Requires matching `data-*` fields on list items for each listed category.
 - `wt-cmsfilter-trigger="button"` - Changes filter trigger to button submit instead of real-time
 - `wt-cmsfilter-class="classname"` - CSS class applied to active filter elements
 - `wt-cmsfilter-resetix2="true"` - Reset IX2 interactions on filtered items

--- a/docs/WebflowOnly/CMSFilter.md
+++ b/docs/WebflowOnly/CMSFilter.md
@@ -12,6 +12,7 @@ CMSFilter is a powerful Webflow-specific script that provides advanced filtering
 
 - Multiple filter types (checkbox, radio, text, range)
 - Advanced filtering with dynamic availability updates
+- Hybrid filtering mode (`hybrid`): advanced-style narrowing for **make** and other facets, while **body type** options stay available for multi-select
 - Pagination support with auto-loading across pages
 - Dynamic sorting (numeric, date, alphabetical)
 - Active filter tags with individual removal
@@ -46,7 +47,8 @@ Add the script to your Webflow project and include the required attributes on yo
 
 #### Core Filter Attributes
 
-- `wt-cmsfilter-filtering="advanced"` - Enables advanced filtering mode with dynamic availability updates
+- `wt-cmsfilter-filtering="advanced"` - Enables advanced filtering mode with dynamic availability updates (every facet’s options narrow to the current result set; selecting one **make** hides other makes).
+- `wt-cmsfilter-filtering="hybrid"` - Like advanced, but **`bodytype`** keeps **all** of its checkbox options that match the current filters **except** body type (so users can multi-select e.g. Minivan and SUV while other facets react). **`make`** and all other categories narrow from the current result set like **`advanced`**. Requires matching `data-bodytype` on list items (`wt-cmsfilter-category="bodytype"`).
 - `wt-cmsfilter-trigger="button"` - Changes filter trigger to button submit instead of real-time
 - `wt-cmsfilter-class="classname"` - CSS class applied to active filter elements
 - `wt-cmsfilter-resetix2="true"` - Reset IX2 interactions on filtered items


### PR DESCRIPTION
# New Feature: [Feature Title]

## Description
Adds a new CMS Filtering option, Hybrid. 
Adds a new attribute which specifies items to be excluded from the filter-narrowing, effectively leaving some categories multi-select. 

## Changes Made
This pull request introduces and documents a new "hybrid" filtering mode for the CMSFilter Webflow script, which allows specific facets (like body type) to keep all relevant checkbox options visible for multi-select, while other facets behave as in advanced mode. The changes include new tests to verify hybrid behavior and comprehensive documentation updates explaining how to use the hybrid mode and its configuration.

Key changes:

**Feature: Hybrid Filtering Mode**
* Added a new "hybrid" filtering mode, controlled via the `wt-cmsfilter-filtering="hybrid"` attribute and configured with `wt-cmsfilter-hybrid-categories` to specify which facets retain all relevant options for multi-select. [[1]](diffhunk://#diff-c78a4b062370e00c4023df06b829a221e80a19f9a5e218c07c0d19e9498646e5L49-R52) [[2]](diffhunk://#diff-c78a4b062370e00c4023df06b829a221e80a19f9a5e218c07c0d19e9498646e5R216-R236)
* Updated documentation to describe hybrid mode usage, configuration, and how it differs from advanced mode, including example markup and guidance for multiple hybrid facets. [[1]](diffhunk://#diff-c78a4b062370e00c4023df06b829a221e80a19f9a5e218c07c0d19e9498646e5R15) [[2]](diffhunk://#diff-c78a4b062370e00c4023df06b829a221e80a19f9a5e218c07c0d19e9498646e5L49-R52) [[3]](diffhunk://#diff-c78a4b062370e00c4023df06b829a221e80a19f9a5e218c07c0d19e9498646e5R216-R236) [[4]](diffhunk://#diff-c78a4b062370e00c4023df06b829a221e80a19f9a5e218c07c0d19e9498646e5L250-R274)

**Testing: Hybrid Mode Behavior**
* Added `buildHybridScenarioDOM` helper to the test suite to construct DOM scenarios for hybrid and advanced filtering modes.
* Added tests verifying that in hybrid mode, specified categories (like bodytype) keep all relevant options visible for multi-select, while other facets narrow as in advanced mode. Also tested hybrid mode with empty hybrid categories (behaves like advanced), and compared with advanced mode behavior.


## Checklist
<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] Feature has been tested locally with all relevant use cases.
- [x] Documentation has been updated (if necessary).
- [x] PR does not match another non-stale PR currently opened
- [x] PR name matches the format *[ feature ]: <i>Feature Name</i> (<i>versions separated by comma</i>)*. More details [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Overview-on-Submitting-Features)
- [x] PR's base is the `develop` branch.
- [x] Your Feature matches the standards laid out [here](https://github.com/TheCodeRaccoons/WebTricks/wiki/Programming-Standards)
<!-- Refer to the [contributing](https://github.com/TheCodeRaccoons/WebTricks/wiki/Contributing) guidelines for more details. -->

## Additional Notes
Add any extra details or comments for reviewers.
